### PR TITLE
Store unmapped ADL types in postgres as jsonb instead of json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .doit.db
 build
+/.doit*

--- a/lib/ADL/Sql/SchemaUtils.hs
+++ b/lib/ADL/Sql/SchemaUtils.hs
@@ -12,6 +12,7 @@ module ADL.Sql.SchemaUtils
   , localDateType
   , localDateTimeType
   , postgresDbProfile
+  , postgresDbProfileV2
   , mssqlDbProfile
   , DbProfile
   ) where
@@ -61,6 +62,25 @@ postgresDbProfile = DbProfile {
     P_Double -> "double precision"
     P_Bool -> "boolean"
     _ -> "json"
+}
+
+postgresDbProfileV2 = DbProfile {
+  dbp_idColumnType="text",
+  dbp_enumColumnType="text",
+  dbp_primColumnType= \p -> case p of
+    P_String -> "text"
+    P_Int8 -> "smalllint"
+    P_Int16 -> "smalllint"
+    P_Int32 -> "integer"
+    P_Int64 -> "bigint"
+    P_Word8 -> "smalllint"
+    P_Word16 -> "smalllint"
+    P_Word32 -> "integer"
+    P_Word64 -> "bigint"
+    P_Float -> "real"
+    P_Double -> "double precision"
+    P_Bool -> "boolean"
+    _ -> "jsonb"
 }
 
 mssqlDbProfile = DbProfile {
@@ -245,7 +265,7 @@ rawColumnFromField dbp field = mkColumn M.empty False (f_type field)
     mkColumn _ nullable te@(TypeExpr (RT_Primitive p) _) =
       mkRawColumn nullable (mkColumnType p) te
 
-    -- For any other types, just store as json
+    -- For any other types, just store as jsonb
     mkColumn _ nullable te =
       mkRawColumn nullable (mkColumnType P_Json) te
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,7 +11,7 @@ import ADL.Compiler.EIO
 import ADL.Compiler.Flags(parseArguments,standardOptions,updateBackendFlags,Flags(..))
 import ADL.Compiler.Processing(loadAndCheckModule,defaultAdlFlags)
 import ADL.Compiler.Utils(writeOutputFile)
-import ADL.Sql.SchemaUtils(schemaFromAdl,sqlFromSchema, DbProfile, postgresDbProfile, mssqlDbProfile)
+import ADL.Sql.SchemaUtils(schemaFromAdl,sqlFromSchema, DbProfile, postgresDbProfile, postgresDbProfileV2, mssqlDbProfile)
 import ADL.Sql.JavaTables(generateJavaTables)
 import ADL.Http.JavaReqs(generateJavaReqs)
 import ADL.Http.TypescriptReqs(generateTypescriptReqs)
@@ -50,6 +50,10 @@ schemaOptions :: [OptDescr (Flags SchemaFlags -> Flags SchemaFlags)]
 schemaOptions
   =  [ Option "" ["postgres"] (NoArg (updateBackendFlags (\f -> f{sf_dbProfile=postgresDbProfile})))
        "Generate postgres compatible sql (default)"
+
+     ,  Option "" ["postgres-v2"] (NoArg (updateBackendFlags (\f -> f{sf_dbProfile=postgresDbProfileV2})))
+       "Generate postgres 9.6+ compatible sql (eg including jsonb)"
+
      ,  Option "" ["mssql"] (NoArg (updateBackendFlags (\f -> f{sf_dbProfile=mssqlDbProfile})))
        "Generate microsoft sqlserver compatible sql"
      ]


### PR DESCRIPTION
Since postgres 9.4 but especially since 9.6 it has had good support for jsonb
Plain json column stores in the DB as a string and only basically parses out the json when needed.
Jsonb column stores it in the DB as a parsed and binary - postgres has much better capabilities on jsonb than json columns.

https://www.compose.com/articles/faster-operations-with-the-jsonb-data-type-in-postgresql/
https://www.postgresql.org/docs/9.6/functions-json.html