### PR TITLE
Generate postgis 'geometry' column type for common.GeometryWKT newtype

### DIFF
--- a/lib/ADL/Sql/JavaTables.hs
+++ b/lib/ADL/Sql/JavaTables.hs
@@ -321,6 +321,8 @@ javaDbType col field
   | SC.typeExprReferences SC.localDateTimeType te = "java.time.LocalDateTime"
   | SC.typeExprReferences SC.localDateType te = "java.time.LocalDate"
   | SC.typeExprReferences SC.geographyType te = "org.postgis.PGgeometry"
+  | SC.typeExprReferences SC.geographyGeoJsonType te = "org.postgis.PGgeometry"
+  | SC.typeExprReferences SC.geometryWKTType te = "org.postgis.PGgeometry"
   | SC.column_ctype col == "double precision" = "Double"
   | "float" `T.isPrefixOf` SC.column_ctype col = "Double"
   | otherwise = "unimp:" <> SC.column_ctype col
@@ -344,6 +346,7 @@ adlFromDbExpr col field expr = do
             _ -> template ".map(v -> $1)" [expr1]
       return (template "Optional.ofNullable($1)$2" [expr,mapExpr])
     (False,_,"geography",_) -> return expr
+    (False,_,"geometry",_) -> return expr
     (False,Just _,_,_) -> do
       return (template "new $1($2)" [J.fd_typeExprStr fdetails,expr])
     (False,_,"timestamp",_) -> return expr
@@ -374,6 +377,7 @@ dbFromAdlExpr col field expr = do
             _ -> template ".map(v -> $1)" [expr1]
       return (template "$1$2.orElse(null)" [expr,mapExpr])
     (False,_,"geography",_) -> return expr
+    (False,_,"geometry",_) -> return expr
     (False,Just _,_,_) -> do
       return (template "$1.getValue()" [expr])
     (False,_,"timestamp",_) -> return expr

--- a/lib/ADL/Sql/SchemaUtils.hs
+++ b/lib/ADL/Sql/SchemaUtils.hs
@@ -7,6 +7,8 @@ module ADL.Sql.SchemaUtils
   , typeExprReferences
   , instantType
   , geographyType
+  , geographyGeoJsonType
+  , geometryWKTType
   , localDateType
   , localDateTimeType
   , postgresDbProfile
@@ -221,6 +223,8 @@ rawColumnFromField dbp field = mkColumn M.empty False (f_type field)
       | typeExprReferences localDateType te = mkRawColumn nullable "date" te
       | typeExprReferences localDateTimeType te = mkRawColumn nullable "timestamp" te
       | typeExprReferences geographyType te = mkRawColumn nullable "geography" te
+      | typeExprReferences geographyGeoJsonType te = mkRawColumn nullable "geography" te
+      | typeExprReferences geometryWKTType te = mkRawColumn nullable "geometry" te
     mkColumn _ nullable te@(TypeExpr ref [])  | isEnumeration2 ref =
       mkRawColumn nullable (dbp_enumColumnType dbp) te
 
@@ -335,4 +339,6 @@ instantType = ScopedName (ModuleName ["common"]) "Instant"
 localDateType = ScopedName (ModuleName ["common"]) "LocalDate"
 localDateTimeType = ScopedName (ModuleName ["common"]) "LocalDateTime"
 geographyType = ScopedName (ModuleName ["common"]) "Geography"
+geographyGeoJsonType = ScopedName (ModuleName ["common"]) "GeographyGeoJson"
+geometryWKTType = ScopedName (ModuleName ["common"]) "GeometryWKT"
 maybeType = ScopedName (ModuleName ["sys","types"]) "Maybe"


### PR DESCRIPTION
Add support for type common.GeographyGeoJson
- clarify it as string serialised in GeoJson format.

Add support for type common.GeometryWKT
- serialised as String in WKT ("well known text") format
https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry