### PR TITLE
adl java  tables v2

### DIFF
--- a/haskell/hx-adl/helix-adl-tools.cabal
+++ b/haskell/hx-adl/helix-adl-tools.cabal
@@ -39,7 +39,9 @@ library
   hs-source-dirs:      lib
   exposed-modules:     ADL.Sql.Schema
                      , ADL.Sql.SchemaUtils
+                     , ADL.Sql.JavaUtils
                      , ADL.Sql.JavaTables
+                     , ADL.Sql.JavaTablesV2
                      , ADL.Http.JavaReqs
                      , ADL.Http.TypescriptReqs
                      , ADL.Http.Utils

--- a/haskell/hx-adl/lib/ADL/Sql/JavaTablesV2.hs
+++ b/haskell/hx-adl/lib/ADL/Sql/JavaTablesV2.hs
@@ -216,7 +216,7 @@ genDbConversionExpr1 cgp texpr@(AST.TypeExpr (RT_Primitive p) tparams) =
 genDbConversionExpr1 cgp texpr
   | refEnumeration texpr = do
     typeExprStr <- J.genTypeExprB J.TypeBoxed texpr
-    return (template "DbConversions.dbenum(s -> $1.fromString(s), e -> e.toString())" [typeExprStr])
+    return (template "DbConversions.dbEnum(s -> $1.fromString(s), e -> e.toString())" [typeExprStr])
   | SC.typeExprReferences SC.instantType texpr = return "DbConversions.INSTANT"
   | SC.typeExprReferences SC.localDateTimeType texpr = return "DbConversions.LOCAL_DATE_TIME"
   | SC.typeExprReferences SC.localDateType texpr = return "DbConversions.LOCAL_DATE"

--- a/haskell/hx-adl/lib/ADL/Sql/JavaTablesV2.hs
+++ b/haskell/hx-adl/lib/ADL/Sql/JavaTablesV2.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ADL.Sql.JavaTablesV2 where
+
+import qualified ADL.Compiler.AST as AST
+import qualified ADL.Compiler.Backends.Java as J
+import qualified ADL.Compiler.Backends.Java.Internal as J
+import qualified ADL.Sql.Schema as SC
+import qualified ADL.Sql.SchemaUtils as SC
+import qualified Data.Aeson as JS
+import qualified Data.Text as T
+
+import ADL.Compiler.Primitive
+import ADL.Compiler.Processing(AdlFlags(..),ResolvedType(..), RModule,RDecl,defaultAdlFlags,loadAndCheckModule1,removeModuleTypedefs, expandModuleTypedefs, associateCustomTypes, refEnumeration, refNewtype, ResolvedTypeT(..))
+import ADL.Sql.JavaUtils
+import ADL.Utils.Format(template,formatText)
+import ADL.Utils.IndentedCode
+import Control.Monad.Trans.State.Strict
+import Data.Foldable(for_)
+import Data.Traversable(for)
+import Utils(toSnakeCase)
+
+generateJavaModelV2 :: JavaTableFlags -> J.CodeGenProfile -> J.JavaPackageFn -> J.CModule -> DBTable -> J.ClassFile
+generateJavaModelV2 jtflags cgp javaPackageFn mod dbtable@(_,_,_,dbTableAnnotation)  =
+  case getAnnotationField dbTableAnnotation "withIdPrimaryKey" of
+    (Just (JS.Bool True)) -> generateClassWithIdPrimaryKey jtflags cgp javaPackageFn mod dbtable
+    _ -> generateClass jtflags cgp javaPackageFn mod dbtable
+
+
+generateClassWithIdPrimaryKey :: JavaTableFlags -> J.CodeGenProfile -> J.JavaPackageFn -> J.CModule -> DBTable -> J.ClassFile
+generateClassWithIdPrimaryKey jtflags cgp javaPackageFn mod dbtable = execState gen state0
+  where
+    (tableClassNameT,tableInstanceNameT,javaClassNameT,dbTableNameT) = mkNames dbtable
+    (decl,struct,table,dbTableAnnotation) = dbtable
+    state0 = J.classFile cgp (AST.m_name mod) javaPackageFn classDecl
+    classDecl = template "@SuppressWarnings(\"all\")\npublic class $1 extends AdlTableWithId<$2>" [tableClassNameT,javaClassNameT]
+    gen = do
+      generateClassCommon dbtable
+
+      adlColumns <- mkAdlColumns cgp (SC.table_columns table) (AST.s_fields struct)
+
+      J.addMethod
+        (  ctemplate "private final AdlField<DbKey<$1>> id = f(\"id\", DbConversions.dbKey(), DbKey.jsonBinding($1.jsonBinding()));"
+                       [javaClassNameT]
+        <> ctemplate "public AdlField<DbKey<$1>> id() { return id; }" [javaClassNameT]
+        )
+      for_ adlColumns $ \dbc -> case dbc of
+        (col,fd,jb,dbconv) -> do
+          J.addMethod
+            (  ctemplate "private final AdlField<$1> $2 = f(\"$3\", $4, $5);"
+                         [J.fd_boxedTypeExprStr fd, J.fd_varName fd, SC.column_name col, dbconv, jb]
+            <> ctemplate "public AdlField<$1> $2() { return $2; }"
+                         [J.fd_boxedTypeExprStr fd, J.fd_varName fd]
+            )
+
+      J.addMethod
+        (  cline "@Override"
+        <> cblock "public List<AdlField<?>> allFields()"
+           (  cline "List<AdlField<?>> result = new ArrayList<>();"
+           <> cline "result.add(id);"
+           <> mconcat [ ctemplate "result.add($1);" [J.fd_varName fd] | (_,fd,_,_) <- adlColumns]
+           <> cline "return result;"
+           )
+        )
+
+      J.addMethod
+        (  cline "@Override"
+        <> cblock (template "public WithDbId<$1> fromDbResults(DbResults res) throws SQLException" [javaClassNameT])
+           (  ctemplate "$1 result = new $1(" [javaClassNameT]
+           <> indent (mconcat [ctemplate "$1().fromDb(res)$2" [J.fd_varName fd,mcomma]
+                              | ((_,fd,_,_),mcomma) <- withCommas adlColumns])
+           <> cline ");"
+           <> ctemplate "return new WithDbId<$1>(id().fromDb(res), result);" [javaClassNameT]
+           )
+        )
+
+      J.addMethod
+        (  cline "@Override"
+        <> cblock (template "public Map<Dsl.FieldRef, Object> dbMapping(DbKey<$1> id, $1 value)" [javaClassNameT])
+           (  cline "Map<Dsl.FieldRef, Object> result = new HashMap<>();"
+           <> cline "result.put( id(), id().toDb(id));"
+           <> mconcat [ctemplate "result.put($1(), $1().toDb(value.$2()));" [J.fd_varName fd, J.fd_accessorName fd]
+                      | (_,fd,_,_) <- adlColumns]
+           <> cline "return result;"
+           )
+        )
+
+generateClass :: JavaTableFlags -> J.CodeGenProfile -> J.JavaPackageFn -> J.CModule -> DBTable -> J.ClassFile
+generateClass jtflags cgp javaPackageFn mod dbtable = execState gen state0
+  where
+    (tableClassNameT,tableInstanceNameT,javaClassNameT,dbTableNameT) = mkNames dbtable
+    (decl,struct,table,dbTableAnnotation) = dbtable
+    state0 = J.classFile cgp (AST.m_name mod) javaPackageFn classDecl
+    classDecl = template "@SuppressWarnings(\"all\")\npublic class $1 extends AdlTable<$2>" [tableClassNameT,javaClassNameT]
+    gen = do
+      generateClassCommon dbtable
+
+      adlColumns <- mkAdlColumns cgp (SC.table_columns table) (AST.s_fields struct)
+
+      for_ adlColumns $ \dbc -> case dbc of
+        (col,fd,jb,dbconv) -> do
+          J.addMethod
+            (  ctemplate "private final AdlField<$1> $2 = f(\"$3\", $4, $5);"
+                         [J.fd_boxedTypeExprStr fd, J.fd_varName fd, SC.column_name col, dbconv, jb]
+            <> ctemplate "public AdlField<$1> $2() { return $2; }"
+                         [J.fd_boxedTypeExprStr fd, J.fd_varName fd]
+            )
+
+      J.addMethod
+        (  cline "@Override"
+        <> cblock "public List<AdlField<?>> allFields()"
+           (  cline "List<AdlField<?>> result = new ArrayList<>();"
+           <> mconcat [ ctemplate "result.add($1);" [J.fd_varName fd] | (_,fd,_,_) <- adlColumns]
+           <> cline "return result;"
+           )
+        )
+
+      J.addMethod
+        (  cline "@Override"
+        <> cblock (template "public $1 fromDbResults(DbResults res) throws SQLException" [javaClassNameT])
+           (  ctemplate "$1 result = new $1(" [javaClassNameT]
+           <> indent (mconcat [ctemplate "$1().fromDb(res)$2" [J.fd_varName fd,mcomma]
+                              | ((_,fd,_,_),mcomma) <- withCommas adlColumns])
+           <> cline ");"
+           <> ctemplate "return result;" [javaClassNameT]
+           )
+        )
+
+      J.addMethod
+        (  cline "@Override"
+        <> cblock (template "public Map<Dsl.FieldRef, Object> dbMapping(DbKey<$1> id, $1 value)" [javaClassNameT])
+           (  cline "Map<Dsl.FieldRef, Object> result = new HashMap<>();"
+           <> mconcat [ctemplate "result.put($1(), $1().toDb(value.$2()));" [J.fd_varName fd, J.fd_accessorName fd]
+                      | (_,fd,_,_) <- adlColumns]
+           <> cline "return result;"
+           )
+        )
+
+
+mkNames :: DBTable -> (T.Text,T.Text,T.Text,T.Text)
+mkNames (decl,struct,table,dbTableAnnotation) = (tableClassNameT,tableInstanceNameT,javaClassNameT,dbTableNameT)
+  where
+    tableClassNameT = tableClassName decl
+    tableInstanceNameT = T.toUpper (toSnakeCase (AST.d_name decl))
+    javaClassNameT = javaClassName decl
+    dbTableNameT = dbTableName decl
+
+generateClassCommon :: DBTable -> J.CState ()
+generateClassCommon dbtable  = do
+  let (tableClassNameT,tableInstanceNameT,javaClassNameT,dbTableNameT) = mkNames dbtable
+
+  rtPackage <- J.getRuntimePackage
+  J.addImport "au.com.helixta.adl.common.db.DbKey"
+  J.addImport "au.com.helixta.adl.common.db.WithDbId"
+  J.addImport "au.com.helixta.adl.util.AdlField"
+  J.addImport "au.com.helixta.adl.util.AdlTableWithId"
+  J.addImport "au.com.helixta.adl.util.DbConversions"
+  J.addImport "au.com.helixta.nofrills.sql.Dsl"
+  J.addImport "au.com.helixta.nofrills.sql.impl.DbResults"
+  J.addImport (J.javaClass rtPackage "JsonBindings")
+  J.addImport (J.javaClass rtPackage "JsonBinding")
+  J.addImport "javax.annotation.Nullable"
+  J.addImport "java.sql.SQLException"
+  J.addImport "java.util.ArrayList"
+  J.addImport "java.util.List"
+  J.addImport "java.util.HashMap"
+  J.addImport "java.util.Map"
+
+  J.addMethod (ctemplate "public static final $1 $2 = new $1();" [tableClassNameT, tableInstanceNameT])
+
+  J.addMethod (cblock (template "public $1()" [tableClassNameT]) (
+    ctemplate "super(\"$1\");" [dbTableNameT]
+    ))
+
+  J.addMethod (cblock (template "public $1(String alias)" [tableClassNameT]) (
+    ctemplate "super(\"$1\", alias);" [dbTableNameT]
+    ))
+
+  J.addMethod (cblock (template "public $1(String tablename, @Nullable String alias)" [tableClassNameT]) (
+    cline "super(tablename, alias);"
+        ))
+
+  J.addMethod
+    (  cline "@Override"
+    <> cblock (template "public JsonBinding<$1> jsonBinding()" [javaClassNameT])
+       ( ctemplate "return $1.jsonBinding();" [javaClassNameT])
+    )
+
+
+
+genDbConversionExpr:: J.CodeGenProfile -> SC.Column -> AST.TypeExpr J.CResolvedType -> J.CState T.Text
+genDbConversionExpr cgp col texpr@(AST.TypeExpr _ tparams) =  case SC.column_nullable col of
+  False -> genDbConversionExpr1 cgp texpr
+  True -> do
+    dbconv <- genDbConversionExpr1 cgp (head tparams)
+    return (template "DbConversions.nullable($1)" [dbconv])
+
+genDbConversionExpr1:: J.CodeGenProfile -> AST.TypeExpr J.CResolvedType -> J.CState T.Text
+genDbConversionExpr1 cgp texpr@(AST.TypeExpr (RT_Primitive p) tparams) =
+  case p of
+    P_Bool -> return "DbConversions.BOOLEAN"
+    P_Int8 -> return "DbConversions.BYTE"
+    P_Int16 -> return "DbConversions.SHORT"
+    P_Int32 -> return "DbConversions.INTEGER"
+    P_Int64 -> return "DbConversions.LONG"
+    P_Word8 -> return "DbConversions.BYTE"
+    P_Word16 -> return "DbConversions.SHORT"
+    P_Word32 -> return "DbConversions.INTEGER"
+    P_Word64 -> return "DbConversions.LONG"
+    P_Float -> return "DbConversions.FLOAT"
+    P_Double -> return "DbConversions.DOUBLE"
+    P_String -> return "DbConversions.STRING"
+    _ -> do
+      jb <- J.genJsonBindingExpr cgp texpr
+      return (template "DbConversions.json($1)" [jb])
+genDbConversionExpr1 cgp texpr
+  | refEnumeration texpr = do
+    typeExprStr <- J.genTypeExprB J.TypeBoxed texpr
+    return (template "DbConversions.dbenum(s -> $1.fromString(s), e -> e.toString())" [typeExprStr])
+  | SC.typeExprReferences SC.instantType texpr = return "DbConversions.INSTANT"
+  | SC.typeExprReferences SC.localDateTimeType texpr = return "DbConversions.LOCAL_DATE_TIME"
+  | SC.typeExprReferences SC.localDateType texpr = return "DbConversions.LOCAL_DATE"
+  | SC.typeExprReferences SC.dbKeyType texpr = return "DbConversions.dbKey()"
+  | otherwise = do
+      jb <- J.genJsonBindingExpr cgp texpr
+      return (template "DbConversions.json($1)" [jb])
+
+type AdlColumn = (SC.Column,J.FieldDetails,T.Text,T.Text)
+
+mkAdlColumns :: J.CodeGenProfile -> [SC.Column] -> [AST.Field J.CResolvedType] -> J.CState [AdlColumn]
+mkAdlColumns cgp columns fields = for (zip nonIdColumns fields) $ \(col, field) -> do
+  fd <- J.genFieldDetails field
+  jb <- J.genJsonBindingExpr cgp (AST.f_type (J.fd_field fd))
+  dbconv <- case customDbHelpers col field of
+    Nothing -> genDbConversionExpr cgp col (AST.f_type (J.fd_field fd))
+    (Just helperClass) -> do
+      case SC.column_nullable col of
+         False -> return (template "$1.dbConversion()" [helperClass])
+         True -> return (template "DbConversions.nullable($1.dbConversion())" [helperClass])
+  return (col,fd,jb,dbconv)
+  where
+    nonIdColumns = filter (\col -> SC.column_name col /= "id") columns

--- a/haskell/hx-adl/lib/ADL/Sql/JavaTablesV2.hs
+++ b/haskell/hx-adl/lib/ADL/Sql/JavaTablesV2.hs
@@ -41,6 +41,7 @@ generateClassWithIdPrimaryKey jtflags cgp javaPackageFn mod dbtable = execState 
       J.addMethod
         (  ctemplate "private final AdlField<DbKey<$1>> id = f(\"id\", DbConversions.dbKey(), DbKey.jsonBinding($1.jsonBinding()));"
                        [javaClassNameT]
+        <> cline "@Override"
         <> ctemplate "public AdlField<DbKey<$1>> id() { return id; }" [javaClassNameT]
         )
       for_ adlColumns $ \dbc -> case dbc of

--- a/haskell/hx-adl/lib/ADL/Sql/JavaUtils.hs
+++ b/haskell/hx-adl/lib/ADL/Sql/JavaUtils.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ADL.Sql.JavaUtils where
+
+import qualified Data.Aeson as JS
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import qualified Data.Map as M
+import qualified ADL.Compiler.AST as AST
+import qualified ADL.Sql.SchemaUtils as SC
+import qualified ADL.Sql.Schema as SC
+import qualified ADL.Compiler.Backends.Java.Internal as J
+import qualified ADL.Compiler.Backends.Java as J
+
+import ADL.Compiler.Processing
+import Utils(toSnakeCase)
+
+data JavaTableFlags = JavaTableFlags {
+  jt_rtpackage :: T.Text,
+  jt_package :: T.Text,
+  jt_crudfns :: Bool,
+  jt_genversion :: GenVersion
+}
+
+data GenVersion = V1 | V2;
+
+defaultJavaTableFlags = JavaTableFlags "adl.runtime" "adl" False V1
+
+type DBTable = (J.CDecl,AST.Struct J.CResolvedType,SC.Table,JS.Value)
+
+
+data DbColumn a
+  = IdColumn SC.Column
+  | DbColumn SC.Column (AST.Field J.CResolvedType) a
+
+mkDbColumns :: Bool -> [SC.Column] -> [AST.Field J.CResolvedType] -> [DbColumn ()]
+mkDbColumns False columns fields = zipWith (\c f -> DbColumn c f ()) columns fields
+mkDbColumns True columns fields = (IdColumn (head columns)): mkDbColumns False(tail columns) fields
+
+javaFieldName :: DbColumn a -> T.Text
+javaFieldName (IdColumn _) = "id"
+javaFieldName (DbColumn _ field _) = J.unreserveWord (AST.f_name field)
+
+withCommas :: [a] -> [(a,T.Text)]
+withCommas [] = []
+withCommas [l] = [(l," ")]
+withCommas (l:ls) = (l,","):withCommas ls
+
+dbTableName :: J.CDecl -> T.Text
+dbTableName decl = case getAnnotation (AST.d_annotations decl) dbTableType of
+  (Just (JS.Object hm)) -> case HM.lookup "tableName" hm of
+    (Just (JS.String t)) -> t
+    _ -> dbName (AST.d_name decl)
+  _ -> dbName (AST.d_name decl)
+
+getAnnotation :: AST.Annotations J.CResolvedType -> AST.ScopedName -> Maybe JS.Value
+getAnnotation annotations annotationName = snd <$> M.lookup annotationName annotations
+
+dbName :: T.Text -> T.Text
+dbName =  toSnakeCase
+
+getAnnotationField :: JS.Value -> T.Text -> Maybe JS.Value
+getAnnotationField (JS.Object hm) field = HM.lookup field hm
+getAnnotationField _ _ = Nothing
+
+dbTableType = AST.ScopedName (AST.ModuleName ["common","db"]) "DbTable"
+javaDbTableVersion = AST.ScopedName (AST.ModuleName ["common","db"]) "JavaDbTableVersion"
+javaDbCustomType = AST.ScopedName (AST.ModuleName ["common","db"]) "JavaDbCustomType"
+withDbIdType = AST.ScopedName (AST.ModuleName ["common","db"]) "WithDbId"
+dbKeyType = AST.ScopedName (AST.ModuleName ["common","db"]) "DbKey"
+
+customDbType :: SC.Column -> AST.Field J.CResolvedType -> Maybe T.Text
+customDbType col field = do
+    jv <- customDbAnnotation col field
+    case getAnnotationField jv "javaDbType" of
+      Nothing -> Nothing
+      (Just (JS.String t)) -> Just t
+
+customDbHelpers :: SC.Column -> AST.Field J.CResolvedType -> Maybe T.Text
+customDbHelpers col field = do
+    jv <- customDbAnnotation col field
+    case getAnnotationField jv "helpers" of
+      Nothing -> Nothing
+      (Just (JS.String t)) -> Just t
+
+-- The annotation can be be on the field, or on the declaration referenced by the field type
+customDbAnnotation :: SC.Column -> AST.Field J.CResolvedType -> Maybe JS.Value
+customDbAnnotation col field = case getAnnotation (AST.f_annotations field) javaDbCustomType of
+   (Just jv) -> Just jv
+   Nothing -> case (SC.column_nullable col,AST.f_type field) of
+      (False, AST.TypeExpr (RT_Named (_,decl))  _) -> getAnnotation (AST.d_annotations decl) javaDbCustomType
+      (True, AST.TypeExpr _ [AST.TypeExpr (RT_Named (_,decl)) _]) -> getAnnotation (AST.d_annotations decl) javaDbCustomType
+      _ -> Nothing
+
+javaTableClassName :: J.CDecl -> T.Text
+javaTableClassName decl = AST.d_name decl <> "Table"
+
+javaClassName :: J.CDecl -> T.Text
+javaClassName decl = AST.d_name decl
+
+tableClassName :: J.CDecl -> T.Text
+tableClassName decl = J.unreserveWord (AST.d_name decl) <> "Table"

--- a/haskell/hx-adl/lib/ADL/Sql/SchemaUtils.hs
+++ b/haskell/hx-adl/lib/ADL/Sql/SchemaUtils.hs
@@ -2,6 +2,7 @@
 module ADL.Sql.SchemaUtils
   ( schemaFromAdl
   , sqlFromSchema
+  , dbKeyType
   , columnFromField
   , columnTypeFromField
   , typeExprReferences

--- a/typescript/hx-adl/src/gen-javatables.ts
+++ b/typescript/hx-adl/src/gen-javatables.ts
@@ -12,6 +12,7 @@ export function configureCli(program: Command) {
    .option('--rtpackage <package>', 'The  package where the ADL runtime can be found')
    .option('--package <package>', 'The  package into which the generated ADL code will be placed')
    .option('--manifest <file>', 'Write a manifest file recording generated files')
+   .option('--genversion <version>', 'Specify the generated table code version')
    .option('--crudfns', 'Generate CRUD helper functions')
    .description('Generate java table definitions')
    .action( (_adlFiles:string[], cmd) => {


### PR DESCRIPTION
Implemented V2 code generator for java db tables

You can control the output code model with the `--genversion` CLI flag, or per table with the `JavaDbTableVersion` annotation.